### PR TITLE
Directivas custom

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,2 @@
-<p>root</p>
+<h2>Custom directive</h2>
+<p capitalize>lorem ipsum dolor</p>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,1 @@
-<h2>Custom directive</h2>
-<p capitalize>lorem ipsum dolor</p>
+<app-custom-directives />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,6 +5,4 @@ import { Component } from '@angular/core';
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent {
-  title = 'apex-angular-bootcamp';
-}
+export class AppComponent {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,10 +3,12 @@ import { BrowserModule } from '@angular/platform-browser';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { CapitalizeDirective } from './directives/capitalize.directive';
 
 @NgModule({
   declarations: [
-    AppComponent
+    AppComponent,
+    CapitalizeDirective
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,11 +4,13 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { CapitalizeDirective } from './directives/capitalize.directive';
+import { CustomDirectivesComponent } from './components/custom-directives/custom-directives.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    CapitalizeDirective
+    CapitalizeDirective,
+    CustomDirectivesComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/custom-directives/custom-directives.component.html
+++ b/src/app/components/custom-directives/custom-directives.component.html
@@ -1,0 +1,2 @@
+<h2>Custom directive</h2>
+<p capitalize>lorem ipsum dolor</p>

--- a/src/app/components/custom-directives/custom-directives.component.ts
+++ b/src/app/components/custom-directives/custom-directives.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-custom-directives',
+  templateUrl: './custom-directives.component.html',
+  styleUrl: './custom-directives.component.scss'
+})
+export class CustomDirectivesComponent {}

--- a/src/app/directives/capitalize.directive.ts
+++ b/src/app/directives/capitalize.directive.ts
@@ -1,0 +1,16 @@
+import { Directive, ElementRef } from '@angular/core';
+
+@Directive({
+  selector: '[capitalize]'
+})
+export class CapitalizeDirective {
+
+  constructor(private readonly element: ElementRef<HTMLElement>) { }
+
+  ngOnInit() {
+    const oldString = this.element.nativeElement.innerText;
+
+    this.element.nativeElement.innerText = oldString.charAt(0).toUpperCase() + oldString.slice(1);
+  }
+
+}


### PR DESCRIPTION
## Requisitos

Crear una nueva directiva “CapitalizeDirective” con el selector `[capitalize]` que al agregarse a un elemento html cualquiera, convierta el texto interno a un texto capitalizado.

## Pantallazos

<img width="272" alt="Screenshot 2024-03-22 at 2 02 07 p m" src="https://github.com/JosueSdev/apex-angular-bootcamp/assets/67652412/50a37b41-c779-4a2c-872f-436160edca84">

<img width="188" alt="Screenshot 2024-03-22 at 2 01 24 p m" src="https://github.com/JosueSdev/apex-angular-bootcamp/assets/67652412/c2533a6e-7133-4db8-9673-f20569a489fb">